### PR TITLE
Add CMake support for Pyhtonic docker image 

### DIFF
--- a/CiCdPythonic/Dockerfile
+++ b/CiCdPythonic/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.1
+FROM python:3.8
 MAINTAINER Biomapas <laimonas.sutkus@biomapas.com>
 
 # Update system.
@@ -8,6 +8,11 @@ RUN \
 
 # Install other python-specific packages.
 RUN pip install pip wheel twine setuptools --upgrade --upgrade-strategy eager
+
+# Install Cmake related libraries.
+RUN \
+    apt-get install -y gcc clang clang-tools cmake && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install node and npm.
 RUN \

--- a/CiCdPythonic/README.md
+++ b/CiCdPythonic/README.md
@@ -1,11 +1,15 @@
-# B.CiCdFull
+# B.CiCdPythonic
 
 Docker based project that creates a docker image with various useful 
 tools required for AWS and Python-heavy pipelines.
 
 ### Description
 
-Project built on latest (python 3.9.1) image.
+Project built on latest (`python:3.8`) image with additional support for:
+
+- `nodejs`
+- `clang`
+- `cmake`
 
 ### Remarks
 


### PR DESCRIPTION
Changes:

- add CMake support for Pyhtonic docker image;
- downgraded base image (`python:3.9.x` -> `python:3.8`) for extended backwards compatibility.