### PR TITLE
Add Gcc & Cmake support for full cicd docker image

### DIFF
--- a/CiCdFull/Dockerfile
+++ b/CiCdFull/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.1
+FROM python:3.8
 MAINTAINER Biomapas <laimonas.sutkus@biomapas.com>
 
 # Update system.
@@ -8,6 +8,11 @@ RUN \
 
 # Install other python-specific packages.
 RUN pip install pip wheel twine setuptools awscli requests --upgrade --upgrade-strategy eager
+
+# Install Gcc/Cmake related libraries.
+RUN \
+    apt-get install -y gcc clang clang-tools cmake && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install node and npm.
 RUN \

--- a/CiCdFull/README.md
+++ b/CiCdFull/README.md
@@ -7,6 +7,12 @@ tools required for AWS, Python, Node infrastructure pipelines.
 
 Docker image that supports both Python and Node environments.
 
+This docker image is built on latest (`python:3.8`) image with additional support for:
+
+- `gcc`
+- `clang`
+- `cmake`
+
 ### Remarks
 
 [Biomapas](https://biomapas.com) aims to modernise life-science 


### PR DESCRIPTION
Added Gcc & Cmake support;
Base image downgraded from python `3.9.x` to `3.8`.