### PR TITLE
Preinstall alternative keyrings backend for cicd-pythonic docker image

### DIFF
--- a/CiCdPythonic/Dockerfile
+++ b/CiCdPythonic/Dockerfile
@@ -27,7 +27,7 @@ RUN \
 # Install AWS CLI.
 RUN pip install awscli
 
-# Add support for alternative keyring backends.Used with Gemfury packages.
+# Add support for alternative keyring backends. Used with Gemfury packages.
 RUN pip install keyrings.alt
 
 ENTRYPOINT []

--- a/CiCdPythonic/Dockerfile
+++ b/CiCdPythonic/Dockerfile
@@ -27,4 +27,7 @@ RUN \
 # Install AWS CLI.
 RUN pip install awscli
 
+# Add support for alternative keyring backends.Used with Gemfury packages.
+RUN pip install keyrings.alt
+
 ENTRYPOINT []


### PR DESCRIPTION
This package allows for a greater support of different source distribution services like Gemfury.

Can not install this package afterwards as it requires access to `/.local`.